### PR TITLE
++issue fixes++

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ If dependencies are missing, clear instructions and download links are provided.
 
 ## 🛠️ Installation
 
-### Option 1: Download Pre-built Binary
+### 1️⃣ Option 1: Download Pre-built Binary
 
 Download `Image-Tool.exe` from the [Releases](https://github.com/nameIess/Image-Tool/releases) page.
 
-### Option 2: Build from Source
+### 2️⃣ Option 2: Build from Source
 
 **Requirements:** Go 1.21 or higher
 
@@ -224,7 +224,6 @@ This application follows strict security principles:
 - ✅ User-managed dependencies only
 
 ## 👨‍💻 Development
-
 ### 🏗️ Building with Version Info (Windows)
 
 To embed version information in the Windows executable:

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ If dependencies are missing, clear instructions and download links are provided.
 
 ## 🛠️ Installation
 
-### 1️⃣ Option 1: Download Pre-built Binary
+### Option 1: Download Pre-built Binary
 
 Download `Image-Tool.exe` from the [Releases](https://github.com/nameIess/Image-Tool/releases) page.
 
-### 2️⃣ Option 2: Build from Source
+### Option 2: Build from Source
 
 **Requirements:** Go 1.21 or higher
 
@@ -224,6 +224,7 @@ This application follows strict security principles:
 - ✅ User-managed dependencies only
 
 ## 👨‍💻 Development
+
 ### 🏗️ Building with Version Info (Windows)
 
 To embed version information in the Windows executable:


### PR DESCRIPTION
## 📝 Pull Request Title

Fix Fixed File Size compression input handling and support decimal values

## 🧩 Changes Made

Describe the changes introduced by this pull request.

- **Fixed unit input not receiving keyboard input**: Moved the `unitInput.Focused()` check to the beginning of the `CompressStepSetFixedSize` case, so the unit input field properly receives and handles keystrokes when focused.
- **Added support for decimal size values**: Changed `sizeValue` from `int` to `float64` to allow users to enter values like `0.5 MB`.
- **Updated parsing logic**: Replaced `strconv.Atoi` with `strconv.ParseFloat` for all size input parsing.
- **Fixed byte calculations**: Updated calculations to properly handle float multiplication (e.g., `int64(m.sizeValue * 1024 * 1024)` instead of `int64(m.sizeValue) * 1024 * 1024`).
- **Updated display format**: Changed format strings from `%d` to `%.2g` to properly display decimal values.

## 🔗 Related Issues

Link to any related issues or pull requests.

- Fixes issue where unit input field was unresponsive after entering size value
- Fixes issue where entering `0.5` defaulted to `100` due to integer parsing

## 🧪 Testing Done

What testing was performed to ensure the changes work correctly?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
  - Verified unit input (B, KB, MB) now accepts keyboard input
  - Verified decimal values like `0.5` are correctly parsed
  - Verified `0.5 MB` correctly calculates to 524,288 bytes
  - Verified shortcut keys (K, M, B) work with decimal values

## 📸 Screenshots or Demos (if applicable)

Before fix:
- Entering `0.5` → Defaulted to `100 MB` (integer parsing failed)
- Unit input field did not accept any keyboard input

After fix:
- Entering `0.5` + `MB` → Correctly shows `0.5 MB (512.0 KB)`
- Unit input field properly accepts B, KB, or MB

## ✅ Checklist

Please ensure the following are completed before submitting:

- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if applicable)
- [x] No breaking changes introduced

## 💻 Environment Details

If applicable, provide details about the environment where changes were tested:

- OS: Windows
- Go version: 1.21+

## 🧾 Additional Context

The root cause of the unit input issue was the order of checks in the `Update` function. The `unitInput.Focused()` check was placed after the main key handling block, so messages were being processed by the `sizeInput` handlers first, preventing the unit input from ever receiving them.

Files modified:
- `internal/ui/compressor.go`